### PR TITLE
feat: dynamic macros for shared exclusions

### DIFF
--- a/macros/shared_exclusions/shared_exclusions__exclude_advanced_illness.sql
+++ b/macros/shared_exclusions/shared_exclusions__exclude_advanced_illness.sql
@@ -1,0 +1,319 @@
+{% macro shared_exclusions__exclude_advanced_illness(denominator_model, concept_names) %}
+
+    {{ config(
+     enabled = var('quality_measures_enabled',var('claims_enabled',var('clinical_enabled',var('tuva_marts_enabled',false))))
+   )
+}}
+
+with patients_with_frailty as (
+
+    {%- set result = shared_exclusions__frailty(denominator_model) -%}
+    {{result}}
+
+)
+
+, exclusion_codes as (
+
+    select
+          code
+        , code_system
+        , concept_name
+    from {{ ref('quality_measures__value_sets') }}
+    where lower(concept_name) in {{ concept_names }}
+
+)
+
+, conditions as (
+
+    select
+          patient_id
+        , claim_id
+        , recorded_date
+        , coalesce (
+              normalized_code_type
+            , case
+                when lower(source_code_type) = 'snomed' then 'snomed-ct'
+                else lower(source_code_type)
+              end
+          ) as code_type
+        , coalesce (
+              normalized_code
+            , source_code
+          ) as code
+    from {{ ref('quality_measures__stg_core__condition') }}
+
+)
+
+, medical_claim as (
+
+    select
+          patient_id
+        , claim_id
+        , claim_start_date
+        , claim_end_date
+        , hcpcs_code
+        , place_of_service_code
+    from {{ ref('quality_measures__stg_medical_claim') }}
+
+)
+
+, procedures as (
+
+    select
+          patient_id
+        , procedure_date
+        , coalesce (
+              normalized_code_type
+            , case
+                when lower(source_code_type) = 'cpt' then 'hcpcs'
+                when lower(source_code_type) = 'snomed' then 'snomed-ct'
+                else lower(source_code_type)
+              end
+          ) as code_type
+        , coalesce (
+              normalized_code
+            , source_code
+          ) as code
+    from {{ ref('quality_measures__stg_core__procedure') }}
+
+)
+
+, condition_exclusions as (
+
+    select
+          conditions.patient_id
+        , conditions.claim_id
+        , conditions.recorded_date
+        , exclusion_codes.concept_name
+    from conditions
+         inner join exclusion_codes
+            on conditions.code = exclusion_codes.code
+            and conditions.code_type = exclusion_codes.code_system
+    where lower(exclusion_codes.concept_name) = 'advanced illness'
+
+)
+
+, med_claim_exclusions as (
+
+    select
+          medical_claim.patient_id
+        , medical_claim.claim_id
+        , medical_claim.claim_start_date
+        , medical_claim.claim_end_date
+        , medical_claim.hcpcs_code
+        , exclusion_codes.concept_name
+    from medical_claim
+         inner join exclusion_codes
+            on medical_claim.hcpcs_code = exclusion_codes.code
+    where exclusion_codes.code_system = 'hcpcs'
+
+)
+
+, procedure_exclusions as (
+
+    select
+          procedures.patient_id
+        , procedures.procedure_date
+        , exclusion_codes.concept_name
+    from procedures
+         inner join exclusion_codes
+             on procedures.code = exclusion_codes.code
+             and procedures.code_type = exclusion_codes.code_system
+
+)
+
+, acute_inpatient as (
+
+    select distinct
+          patients_with_frailty.patient_id
+        , coalesce(
+              med_claim_exclusions.claim_start_date
+            , med_claim_exclusions.claim_end_date
+          ) as exclusion_date
+        , patients_with_frailty.exclusion_reason
+            || ' with '
+            || med_claim_exclusions.concept_name
+            || ' and '
+            || condition_exclusions.concept_name
+          as exclusion_reason
+    from patients_with_frailty
+         inner join med_claim_exclusions
+            on patients_with_frailty.patient_id = med_claim_exclusions.patient_id
+         inner join condition_exclusions
+            on med_claim_exclusions.claim_id = condition_exclusions.claim_id
+    where med_claim_exclusions.concept_name = 'acute inpatient'
+        and (
+            med_claim_exclusions.claim_start_date
+                between {{ dbt.dateadd(datepart="year", interval=-1, from_date_or_timestamp="patients_with_frailty.performance_period_begin") }}
+                and patients_with_frailty.performance_period_end
+            or med_claim_exclusions.claim_end_date
+                between {{ dbt.dateadd(datepart="year", interval=-1, from_date_or_timestamp="patients_with_frailty.performance_period_begin") }}
+                and patients_with_frailty.performance_period_end
+        )
+
+    union all
+
+    select distinct
+          patients_with_frailty.patient_id
+        , procedure_exclusions.procedure_date as exclusion_date
+        , patients_with_frailty.exclusion_reason
+            || ' with '
+            || procedure_exclusions.concept_name
+            || ' and '
+            || condition_exclusions.concept_name
+          as exclusion_reason
+    from patients_with_frailty
+         inner join procedure_exclusions
+         on patients_with_frailty.patient_id = procedure_exclusions.patient_id
+         inner join condition_exclusions
+         on procedure_exclusions.patient_id = condition_exclusions.patient_id
+         and procedure_exclusions.procedure_date = condition_exclusions.recorded_date
+    where lower(procedure_exclusions.concept_name) = 'acute inpatient'
+    and (
+        procedure_exclusions.procedure_date
+            between {{ dbt.dateadd(datepart="year", interval=-1, from_date_or_timestamp="patients_with_frailty.performance_period_begin") }}
+            and patients_with_frailty.performance_period_end
+    )
+
+)
+
+, nonacute_outpatient as (
+
+    select distinct
+          patients_with_frailty.patient_id
+        , coalesce(
+              med_claim_exclusions.claim_start_date
+            , med_claim_exclusions.claim_end_date
+          ) as exclusion_date
+        , patients_with_frailty.exclusion_reason
+            || ' with '
+            || med_claim_exclusions.concept_name
+            || ' and '
+            || condition_exclusions.concept_name
+          as exclusion_reason
+    from patients_with_frailty
+         inner join med_claim_exclusions
+            on patients_with_frailty.patient_id = med_claim_exclusions.patient_id
+         inner join condition_exclusions
+            on med_claim_exclusions.claim_id = condition_exclusions.claim_id
+    where lower(med_claim_exclusions.concept_name) in (
+              'encounter inpatient'
+            , 'outpatient'
+            , 'observation'
+            , 'emergency department visit'
+            , 'nonacute inpatient'
+        )
+        and (
+            med_claim_exclusions.claim_start_date
+                between {{ dbt.dateadd(datepart="year", interval=-1, from_date_or_timestamp="patients_with_frailty.performance_period_begin") }}
+                and patients_with_frailty.performance_period_end
+            or med_claim_exclusions.claim_end_date
+                between {{ dbt.dateadd(datepart="year", interval=-1, from_date_or_timestamp="patients_with_frailty.performance_period_begin") }}
+                and patients_with_frailty.performance_period_end
+        )
+
+    union all
+
+    select distinct
+          patients_with_frailty.patient_id
+        , procedure_exclusions.procedure_date as exclusion_date
+        , patients_with_frailty.exclusion_reason
+            || ' with '
+            || procedure_exclusions.concept_name
+            || ' and '
+            || condition_exclusions.concept_name
+          as exclusion_reason
+    from patients_with_frailty
+         inner join procedure_exclusions
+         on patients_with_frailty.patient_id = procedure_exclusions.patient_id
+         inner join condition_exclusions
+         on procedure_exclusions.patient_id = condition_exclusions.patient_id
+         and procedure_exclusions.procedure_date = condition_exclusions.recorded_date
+    where lower(procedure_exclusions.concept_name) in (
+          'encounter inpatient'
+        , 'outpatient'
+        , 'observation'
+        , 'emergency department visit'
+        , 'nonacute inpatient'
+    )
+    and (
+        procedure_exclusions.procedure_date
+            between {{ dbt.dateadd(datepart="year", interval=-1, from_date_or_timestamp="patients_with_frailty.performance_period_begin") }}
+            and patients_with_frailty.performance_period_end
+    )
+
+)
+
+, acute_inpatient_counts as (
+
+    select
+          patient_id
+        , count(distinct exclusion_date) as encounter_count
+    from acute_inpatient
+    group by patient_id
+
+)
+
+, nonacute_outpatient_counts as (
+
+    select
+          patient_id
+        , count(distinct exclusion_date) as encounter_count
+    from nonacute_outpatient
+    group by patient_id
+
+)
+
+, eligible_acute_inpatient as (
+
+    select
+          acute_inpatient.patient_id
+        , acute_inpatient.exclusion_date
+        , acute_inpatient.exclusion_reason
+    from acute_inpatient
+         left join acute_inpatient_counts
+         on acute_inpatient.patient_id = acute_inpatient_counts.patient_id
+    where acute_inpatient_counts.encounter_count >= 1
+
+)
+
+, eligible_nonacute_outpatient as (
+
+    select
+          nonacute_outpatient.patient_id
+        , nonacute_outpatient.exclusion_date
+        , nonacute_outpatient.exclusion_reason
+    from nonacute_outpatient
+         left join nonacute_outpatient_counts
+         on nonacute_outpatient.patient_id = nonacute_outpatient_counts.patient_id
+    where nonacute_outpatient_counts.encounter_count >= 2
+
+)
+
+, exclusions_unioned as (
+
+    select
+          eligible_acute_inpatient.patient_id
+        , eligible_acute_inpatient.exclusion_date
+        , eligible_acute_inpatient.exclusion_reason
+    from eligible_acute_inpatient
+
+    union all
+
+    select
+          eligible_nonacute_outpatient.patient_id
+        , eligible_nonacute_outpatient.exclusion_date
+        , eligible_nonacute_outpatient.exclusion_reason
+    from eligible_nonacute_outpatient
+
+)
+
+select
+      patient_id
+    , exclusion_date
+    , exclusion_reason
+    , '{{ var('tuva_last_run')}}' as tuva_last_run
+from exclusions_unioned
+
+
+{% endmacro %}

--- a/macros/shared_exclusions/shared_exclusions__exclude_dementia.sql
+++ b/macros/shared_exclusions/shared_exclusions__exclude_dementia.sql
@@ -1,0 +1,145 @@
+{% macro shared_exclusions__exclude_dementia (denominator_model, concept_names) %}
+    {{ config(
+     enabled = var('quality_measures_enabled',var('claims_enabled',var('clinical_enabled',var('tuva_marts_enabled',false))))
+   )
+}}
+
+with patients_with_frailty as (
+
+    {%- set result = shared_exclusions__frailty(denominator_model) -%}
+    {{result}}
+
+)
+
+, exclusion_codes as (
+
+    select
+          code
+        , code_system
+        , concept_name
+    from {{ ref('quality_measures__value_sets') }}
+    where lower(concept_name) in {{ concept_names  }}
+
+)
+
+, medications as (
+
+    select
+          patient_id
+        , dispensing_date
+        , source_code_type
+        , source_code
+        , ndc_code
+        , rxnorm_code
+    from {{ ref('quality_measures__stg_core__medication') }}
+
+)
+
+, pharmacy_claim as (
+
+    select
+          patient_id
+        , dispensing_date
+        , ndc_code
+        , paid_date
+    from {{ ref('quality_measures__stg_pharmacy_claim') }}
+
+)
+
+, medication_exclusions as (
+
+    select
+          medications.patient_id
+        , medications.dispensing_date
+        , exclusion_codes.concept_name
+    from medications
+         inner join exclusion_codes
+            on medications.ndc_code = exclusion_codes.code
+    where exclusion_codes.code_system = 'ndc'
+
+    union all
+
+    select
+          medications.patient_id
+        , medications.dispensing_date
+        , exclusion_codes.concept_name
+    from medications
+         inner join exclusion_codes
+            on medications.rxnorm_code = exclusion_codes.code
+    where exclusion_codes.code_system = 'rxnorm'
+
+    union all
+
+    select
+          medications.patient_id
+        , medications.dispensing_date
+        , exclusion_codes.concept_name
+    from medications
+         inner join exclusion_codes
+            on medications.source_code = exclusion_codes.code
+            and medications.source_code_type = exclusion_codes.code_system
+
+)
+
+, pharmacy_claim_exclusions as (
+
+    select
+          pharmacy_claim.patient_id
+        , pharmacy_claim.dispensing_date
+        , pharmacy_claim.ndc_code
+        , pharmacy_claim.paid_date
+        , exclusion_codes.concept_name
+    from pharmacy_claim
+         inner join exclusion_codes
+            on pharmacy_claim.ndc_code = exclusion_codes.code
+    where exclusion_codes.code_system = 'ndc'
+
+)
+
+, frailty_with_dementia as (
+
+    select
+          patients_with_frailty.patient_id
+        , patients_with_frailty.exclusion_date
+        , patients_with_frailty.exclusion_reason
+            || ' with '
+            || pharmacy_claim_exclusions.concept_name
+          as exclusion_reason
+    from patients_with_frailty
+         inner join pharmacy_claim_exclusions
+            on patients_with_frailty.patient_id = pharmacy_claim_exclusions.patient_id
+    where (
+        pharmacy_claim_exclusions.dispensing_date
+            between {{ dbt.dateadd(datepart="year", interval=-1, from_date_or_timestamp="patients_with_frailty.performance_period_begin") }}
+            and patients_with_frailty.performance_period_end
+        or pharmacy_claim_exclusions.paid_date
+            between {{ dbt.dateadd(datepart="year", interval=-1, from_date_or_timestamp="patients_with_frailty.performance_period_begin") }}
+            and patients_with_frailty.performance_period_end
+    )
+
+    union all
+
+    select
+          patients_with_frailty.patient_id
+        , medication_exclusions.dispensing_date as exclusion_date
+        , patients_with_frailty.exclusion_reason
+            || ' with '
+            || medication_exclusions.concept_name
+          as exclusion_reason
+    from patients_with_frailty
+         inner join medication_exclusions
+         on patients_with_frailty.patient_id = medication_exclusions.patient_id
+    where medication_exclusions.dispensing_date
+        between {{ dbt.dateadd(datepart="year", interval=-1, from_date_or_timestamp="patients_with_frailty.performance_period_begin") }}
+        and patients_with_frailty.performance_period_end
+
+)
+
+select
+      patient_id
+    , exclusion_date
+    , exclusion_reason
+    , '{{ var('tuva_last_run')}}' as tuva_last_run
+from frailty_with_dementia
+
+{% endmacro %}

--- a/macros/shared_exclusions/shared_exclusions__exclude_institutional_snp.sql
+++ b/macros/shared_exclusions/shared_exclusions__exclude_institutional_snp.sql
@@ -1,0 +1,64 @@
+{% macro shared_exclusions__institutional_snp (denominator_model, place_of_service_codes) %}
+{{ config(
+     enabled = var('quality_measures_enabled',var('claims_enabled',var('clinical_enabled',var('tuva_marts_enabled',false))))
+   )
+}}
+
+
+with denominator as (
+
+    select
+          patient_id
+        , age
+        , performance_period_begin
+        , performance_period_end
+    from {{ denominator_model }}
+
+)
+
+, medical_claim as (
+
+    select
+          patient_id
+        , claim_start_date
+        , claim_end_date
+        , hcpcs_code
+        , place_of_service_code
+    from {{ ref('quality_measures__stg_medical_claim') }}
+
+)
+
+, exclusions as (
+
+    select
+          denominator.patient_id
+        , coalesce(
+              medical_claim.claim_start_date
+            , medical_claim.claim_end_date
+          ) as exclusion_date
+        , 'institutional or long term care' as exclusion_reason
+    from denominator
+         inner join medical_claim
+         on denominator.patient_id = medical_claim.patient_id
+    where denominator.age >= 66
+    and (
+        medical_claim.claim_start_date
+            between denominator.performance_period_begin
+            and denominator.performance_period_end
+        or medical_claim.claim_end_date
+            between denominator.performance_period_begin
+            and denominator.performance_period_end
+    )
+    and place_of_service_code in {{ place_of_service_codes }}
+    and {{ datediff('medical_claim.claim_start_date', 'medical_claim.claim_end_date', 'day') }} >= 90
+
+)
+
+select
+      patient_id
+    , exclusion_date
+    , exclusion_reason
+    , '{{ var('tuva_last_run')}}' as tuva_last_run
+from exclusions
+
+{% endmacro %}

--- a/macros/shared_exclusions/shared_exclusions__frailty.sql
+++ b/macros/shared_exclusions/shared_exclusions__frailty.sql
@@ -1,0 +1,246 @@
+{%- macro shared_exclusions__frailty (denominator_model) %}
+    {{ config(
+     enabled = var('quality_measures_enabled',var('claims_enabled',var('clinical_enabled',var('tuva_marts_enabled',False))))
+    )
+    }}
+
+with denominator as (
+
+    select
+          patient_id
+        , age
+        , performance_period_begin
+        , performance_period_end
+    from {{ denominator_model }}
+
+)
+
+, exclusion_codes as (
+
+    select
+          code
+        , code_system
+        , concept_name
+    from {{ ref('quality_measures__value_sets') }}
+    where lower(concept_name) in (
+          'frailty device'
+        , 'frailty diagnosis'
+        , 'frailty encounter'
+        , 'frailty symptom'
+    )
+    
+
+)
+
+, conditions as (
+
+    select
+          patient_id
+        , recorded_date
+        , coalesce (
+              normalized_code_type
+            , case
+                when lower(source_code_type) = 'snomed' then 'snomed-ct'
+                else lower(source_code_type)
+              end
+          ) as code_type
+        , coalesce (
+              normalized_code
+            , source_code
+          ) as code
+    from {{ ref('quality_measures__stg_core__condition') }}
+
+)
+
+, medical_claim as (
+
+    select
+          patient_id
+        , claim_start_date
+        , claim_end_date
+        , hcpcs_code
+        , place_of_service_code
+    from {{ ref('quality_measures__stg_medical_claim') }}
+
+)
+
+, observations as (
+
+    select
+          patient_id
+        , observation_date
+        , coalesce (
+              normalized_code_type
+            , case
+                when lower(source_code_type) = 'cpt' then 'hcpcs'
+                when lower(source_code_type) = 'snomed' then 'snomed-ct'
+                else lower(source_code_type)
+              end
+          ) as code_type
+        , coalesce (
+              normalized_code
+            , source_code
+          ) as code
+    from {{ ref('quality_measures__stg_core__observation') }}
+
+)
+
+, procedures as (
+
+    select
+          patient_id
+        , procedure_date
+        , coalesce (
+              normalized_code_type
+            , case
+                when lower(source_code_type) = 'cpt' then 'hcpcs'
+                when lower(source_code_type) = 'snomed' then 'snomed-ct'
+                else lower(source_code_type)
+              end
+          ) as code_type
+        , coalesce (
+              normalized_code
+            , source_code
+          ) as code
+    from {{ ref('quality_measures__stg_core__procedure') }}
+
+)
+
+, condition_exclusions as (
+
+    select
+          conditions.patient_id
+        , conditions.recorded_date
+        , exclusion_codes.concept_name
+    from conditions
+         inner join exclusion_codes
+             on conditions.code = exclusion_codes.code
+             and conditions.code_type = exclusion_codes.code_system
+
+)
+
+, med_claim_exclusions as (
+
+    select
+          medical_claim.patient_id
+        , medical_claim.claim_start_date
+        , medical_claim.claim_end_date
+        , medical_claim.hcpcs_code
+        , exclusion_codes.concept_name
+    from medical_claim
+         inner join exclusion_codes
+            on medical_claim.hcpcs_code = exclusion_codes.code
+    where exclusion_codes.code_system = 'hcpcs'
+
+)
+
+, observation_exclusions as (
+
+    select
+          observations.patient_id
+        , observations.observation_date
+        , exclusion_codes.concept_name
+    from observations
+         inner join exclusion_codes
+             on observations.code = exclusion_codes.code
+             and observations.code_type = exclusion_codes.code_system
+
+)
+
+, procedure_exclusions as (
+
+    select
+          procedures.patient_id
+        , procedures.procedure_date
+        , exclusion_codes.concept_name
+    from procedures
+         inner join exclusion_codes
+             on procedures.code = exclusion_codes.code
+             and procedures.code_type = exclusion_codes.code_system
+
+)
+
+, valid_patients_with_frailty as (
+
+    select
+          denominator.patient_id
+        , denominator.performance_period_begin
+        , denominator.performance_period_end
+        , condition_exclusions.recorded_date as exclusion_date
+        , condition_exclusions.concept_name as exclusion_reason
+    from denominator
+         inner join condition_exclusions
+            on denominator.patient_id = condition_exclusions.patient_id
+    where denominator.age >= 66
+        and condition_exclusions.recorded_date
+            between denominator.performance_period_begin
+            and denominator.performance_period_end
+
+    union all
+
+    select
+          denominator.patient_id
+        , denominator.performance_period_begin
+        , denominator.performance_period_end
+        , coalesce(
+              med_claim_exclusions.claim_start_date
+            , med_claim_exclusions.claim_end_date
+          ) as exclusion_date
+        , med_claim_exclusions.concept_name as exclusion_reason
+    from denominator
+         inner join med_claim_exclusions
+            on denominator.patient_id = med_claim_exclusions.patient_id
+    where denominator.age >= 66
+        and (
+            med_claim_exclusions.claim_start_date
+                between denominator.performance_period_begin
+                and denominator.performance_period_end
+            or med_claim_exclusions.claim_end_date
+                between denominator.performance_period_begin
+                and denominator.performance_period_end
+        )
+
+    union all
+
+    select
+          denominator.patient_id
+        , denominator.performance_period_begin
+        , denominator.performance_period_end
+        , observation_exclusions.observation_date as exclusion_date
+        , observation_exclusions.concept_name as exclusion_reason
+    from denominator
+         inner join observation_exclusions
+            on denominator.patient_id = observation_exclusions.patient_id
+    where denominator.age >= 66
+        and observation_exclusions.observation_date
+            between denominator.performance_period_begin
+            and denominator.performance_period_end
+
+    union all
+
+    select
+          denominator.patient_id
+        , denominator.performance_period_begin
+        , denominator.performance_period_end
+        , procedure_exclusions.procedure_date as exclusion_date
+        , procedure_exclusions.concept_name as exclusion_reason
+    from denominator
+         inner join procedure_exclusions
+            on denominator.patient_id = procedure_exclusions.patient_id
+    where denominator.age >= 66
+        and procedure_exclusions.procedure_date
+            between denominator.performance_period_begin
+            and denominator.performance_period_end
+
+)
+
+select
+      patient_id
+    , performance_period_begin
+    , performance_period_end
+    , exclusion_date
+    , exclusion_reason
+    , '{{ var('tuva_last_run')}}' as tuva_last_run
+from valid_patients_with_frailty
+
+{%- endmacro -%}

--- a/macros/shared_exclusions/shared_exclusions__hospice_palliative.sql
+++ b/macros/shared_exclusions/shared_exclusions__hospice_palliative.sql
@@ -1,0 +1,210 @@
+{% macro shared_exclusions__hospice_palliative (denominator_model, concept_names) %}
+
+    {{ config(
+     enabled = var('quality_measures_enabled',var('claims_enabled',var('clinical_enabled',var('tuva_marts_enabled',False)))))
+    }}
+
+
+with exclusion_codes as (
+
+    select
+          code
+        , case code_system
+            when 'SNOMEDCT' then 'snomed-ct'
+            when 'ICD9CM' then 'icd-9-cm'
+            when 'ICD10CM' then 'icd-10-cm'
+            when 'CPT' then 'hcpcs'
+            when 'ICD10PCS' then 'icd-10-pcs'
+          else lower(code_system) end as code_system
+        , concept_name
+    from {{ref('quality_measures__value_sets')}}
+    where lower(concept_name) in {{ concept_names }}
+)
+
+, denominator as (
+
+    select * from {{ denominator_model }}
+
+)
+
+, conditions as (
+
+    select
+          patient_id
+        , claim_id
+        , recorded_date
+        , coalesce (
+              normalized_code_type
+            , case
+                when lower(source_code_type) = 'snomed' then 'snomed-ct'
+                else lower(source_code_type)
+              end
+          ) as code_type
+        , coalesce (
+              normalized_code
+            , source_code
+          ) as code
+    from {{ ref('quality_measures__stg_core__condition') }} 
+
+)
+
+, medical_claim as (
+
+    select
+          patient_id
+        , claim_id
+        , claim_start_date
+        , claim_end_date
+        , hcpcs_code
+        , place_of_service_code
+    from {{ ref('quality_measures__stg_medical_claim') }}
+
+)
+
+, observations as (
+
+    select
+          patient_id
+        , observation_date
+        , coalesce (
+              normalized_code_type
+            , case
+                when lower(source_code_type) = 'cpt' then 'hcpcs'
+                when lower(source_code_type) = 'snomed' then 'snomed-ct'
+                else lower(source_code_type)
+              end
+          ) as code_type
+        , coalesce (
+              normalized_code
+            , source_code
+          ) as code
+    from {{ ref('quality_measures__stg_core__observation') }}
+
+)
+
+, procedures as (
+
+    select
+          patient_id
+        , procedure_date
+        , coalesce (
+              normalized_code_type
+            , case
+                when lower(source_code_type) = 'cpt' then 'hcpcs'
+                when lower(source_code_type) = 'snomed' then 'snomed-ct'
+                else lower(source_code_type)
+              end
+          ) as code_type
+        , coalesce (
+              normalized_code
+            , source_code
+          ) as code
+    from {{ ref('quality_measures__stg_core__procedure') }}
+
+)
+
+, condition_exclusions as (
+
+    select
+          conditions.patient_id
+        , conditions.claim_id
+        , conditions.recorded_date
+        , exclusion_codes.concept_name as concept_name
+    from conditions
+         inner join exclusion_codes
+            on conditions.code = exclusion_codes.code
+            and conditions.code_type = exclusion_codes.code_system
+
+)
+
+, med_claim_exclusions as (
+
+    select
+          medical_claim.patient_id
+        , medical_claim.claim_id
+        , medical_claim.claim_start_date
+        , medical_claim.claim_end_date
+        , medical_claim.hcpcs_code
+        , exclusion_codes.concept_name as concept_name
+    from medical_claim
+         inner join exclusion_codes
+            on medical_claim.hcpcs_code = exclusion_codes.code
+    where exclusion_codes.code_system = 'hcpcs'
+
+)
+
+, observation_exclusions as (
+
+    select
+          observations.patient_id
+        , observations.observation_date
+        , exclusion_codes.concept_name as concept_name
+    from observations
+    inner join exclusion_codes
+        on observations.code = exclusion_codes.code
+        and observations.code_type = exclusion_codes.code_system
+
+)
+
+, procedure_exclusions as (
+
+    select
+          procedures.patient_id
+        , procedures.procedure_date
+        , exclusion_codes.concept_name as concept_name
+    from procedures
+         inner join exclusion_codes
+             on procedures.code = exclusion_codes.code
+             and procedures.code_type = exclusion_codes.code_system
+
+)
+
+, patients_with_exclusions as(
+    select patient_id
+        , recorded_date as exclusion_date
+        , concept_name as exclusion_reason
+    from condition_exclusions
+
+    union all
+
+    select patient_id
+        , coalesce(claim_end_date, claim_start_date) as exclusion_date
+        , concept_name as exclusion_reason
+    from med_claim_exclusions
+
+    union all
+
+    select patient_id
+        , observation_date as exclusion_date
+        , concept_name as exclusion_reason
+    from observation_exclusions
+
+    union all
+
+    select patient_id
+        , procedure_date as exclusion_date
+        , concept_name as exclusion_reason
+    from procedure_exclusions
+
+)
+
+, valid_exclusions as (
+
+    select
+        patients_with_exclusions.*
+    from patients_with_exclusions
+    inner join denominator
+        on patients_with_exclusions.patient_id = denominator.patient_id
+    where patients_with_exclusions.exclusion_date between denominator.performance_period_begin and denominator.performance_period_end
+
+)
+
+select
+      patient_id
+    , exclusion_date
+    , exclusion_reason
+    , '{{ var('tuva_last_run')}}' as tuva_last_run
+from valid_exclusions
+
+
+{% endmacro %}

--- a/models/quality_measures/intermediate/nqf0059_diabetes_hemoglobin_a1c/quality_measures__int_nqf0059_exclusions.sql
+++ b/models/quality_measures/intermediate/nqf0059_diabetes_hemoglobin_a1c/quality_measures__int_nqf0059_exclusions.sql
@@ -3,25 +3,77 @@
    )
 }}
 
-with exclusions as (
+with advanced_illness as (
 
-select *
-from {{ref('quality_measures__int_nqf0059_exclude_advanced_illness')}}
+  {{ shared_exclusions__exclude_advanced_illness(
+      builtins.ref('quality_measures__int_nqf0059_denominator')
+      , concept_names = 
+        "(
+            'advanced illness'
+          , 'acute inpatient'
+          , 'encounter inpatient'
+          , 'outpatient'
+          , 'observation'
+          , 'emergency department visit'
+          , 'nonacute inpatient'
+        )"
+  )}}
 
-union all
+)
 
-select *
-from {{ref('quality_measures__int_nqf0059_exclude_dementia')}}
+, dementia as (
 
-union all
+  {{ shared_exclusions__exclude_dementia(
+      builtins.ref('quality_measures__int_nqf0059_denominator')
+      , concept_names = 
+        "(
+          'dementia medications'
+        )"
+  )}}
 
-select *
-from {{ref('quality_measures__int_nqf0059_exclude_hospice_palliative')}}
+)
 
-union all
+, hospice_palliative as (
 
-select *
-from {{ref('quality_measures__int_nqf0059_exclude_institutional_snp')}}
+  {{ shared_exclusions__hospice_palliative(
+      builtins.ref('quality_measures__int_nqf0059_denominator')
+      , concept_names = 
+        "(
+          'hospice encounter'
+        , 'palliative care encounter'
+        , 'hospice care ambulatory'
+        , 'hospice diagnosis'
+        , 'palliative care diagnosis'
+        )"
+  )}}
+)
+
+, instutional_snp as (
+
+  {{ shared_exclusions__institutional_snp(
+      builtins.ref('quality_measures__int_nqf0059_denominator')
+      , place_of_service_codes = "('32', '33', '34', '54', '56')"
+  )}}
+)
+
+, exclusions as (
+
+  select *
+  from advanced_illness
+
+  union all
+
+  select *
+  from dementia
+
+  union all
+
+  select * from hospice_palliative
+
+  union all
+
+  select *
+  from instutional_snp
 
 )
 


### PR DESCRIPTION
## Describe your changes
This PR aims to resolve the issue of having the same exclsion logic repeated across all quality measures with slight variations. These macros require the denominator model and the codes for the specific quality measure.

## How has this been tested?
This has been tested against the data generated by the production codebase of the Diabetes metric.

## Reviewer focus
Please take a look at the macros and the defined workflow.

## Checklist before requesting a review
- [ ] I have updated the version number in dbt_project.yml file to reflect the release number of this PR
- [x] I have updated the docs files (by running dbt docs generate/serve and copying the necessary files into the docs folder)
- [x] I have commented my code as necessary
- [x] I have added at least one Github label to this PR
- [x] My code follows style guidelines
- [ ] (Optional) I have recorded a Loom to explain this PR


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
